### PR TITLE
fastapi needs specific version 0.112.4 Fixes #6 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "accelerate==0.33.0", "peft", "protobuf", "bitsandbytes",
     "pydantic", "markdown2[all]", "numpy", "scikit-learn==1.2.2",
     "gradio==4.16.0", "gradio_client==0.8.1",
-    "requests", "httpx==0.24.0", "uvicorn", "fastapi",
+    "requests", "httpx==0.24.0", "uvicorn", "fastapi==0.112.4",
     "einops==0.6.1", "einops-exts==0.0.4", "timm==0.6.13",
 ]
 


### PR DESCRIPTION
Hi, 

with the current setup, gradio launches but throws an error same as in the link. 
https://github.com/oobabooga/text-generation-webui/issues/6399

The solution seems to fix the fastapi version. Then, for me at least, it worked. 

Env: 
- Python 3.11